### PR TITLE
Fix indentation, add ‘count’ parameters to ‘update’ and ‘remove’.

### DIFF
--- a/Sources/CountedSet.swift
+++ b/Sources/CountedSet.swift
@@ -34,11 +34,11 @@ public struct CountedSet<T: Hashable>: SetAlgebra {
     }
 
     public init(arrayLiteral elements: CountedSet.Element...) {
-		insert(elements)
-	}
+        insert(elements)
+    }
 
     public init<S: Sequence>(_ sequence: S) where S.Iterator.Element == Element {
-		insert(sequence as! [T])
+        insert(sequence as! [T])
     }
 
     public func countForObject(_ object: Element) -> Int {
@@ -49,38 +49,38 @@ public struct CountedSet<T: Hashable>: SetAlgebra {
         return backingDictionary[member] != nil
     }
 
-	fileprivate mutating func insert(_ members: [T]) {
-		for member in members {
-			let (inserted, existing) = insert(member)
+    fileprivate mutating func insert(_ members: [T]) {
+        for member in members {
+            let (inserted, existing) = insert(member)
 
-			if !inserted {
-				update(with: existing)
-			}
-		}
-	}
+            if !inserted {
+                update(with: existing)
+            }
+        }
+    }
 
-	@discardableResult
-	public mutating func insert(_ newMember: T) -> (inserted: Bool, memberAfterInsert: T) {
-		if backingDictionary.keys.contains(newMember) {
-			return (false, newMember)
-		} else {
-			backingDictionary[newMember] = 1
-			return (true, newMember)
-		}
-	}
+    @discardableResult
+    public mutating func insert(_ newMember: T) -> (inserted: Bool, memberAfterInsert: T) {
+        if backingDictionary.keys.contains(newMember) {
+            return (false, newMember)
+        } else {
+            backingDictionary[newMember] = 1
+            return (true, newMember)
+        }
+    }
 
-	@discardableResult
-	public mutating func update(with newMember: T) -> T? {
-		if let existing = backingDictionary[newMember] {
-			backingDictionary[newMember] = (existing + 1)
-			return newMember
-		} else {
-			backingDictionary[newMember] = 1
-			return nil
-		}
-	}
+    @discardableResult
+    public mutating func update(with newMember: T) -> T? {
+        if let existing = backingDictionary[newMember] {
+            backingDictionary[newMember] = (existing + 1)
+            return newMember
+        } else {
+            backingDictionary[newMember] = 1
+            return nil
+        }
+    }
 
-	@discardableResult
+    @discardableResult
     public mutating func remove(_ member: CountedSet.Element) -> CountedSet.Element? {
         guard let value = backingDictionary[member] else {
             return nil
@@ -173,15 +173,15 @@ public struct CountedSet<T: Hashable>: SetAlgebra {
     public func subtracting(_ other: CountedSet<Element>) -> CountedSet<Element> {
         var subtracted = self
         subtracted.subtract(other)
-        
+
         return subtracted
     }
 
     public func isSubset(of other: CountedSet<Element>) -> Bool {
         for (key, _) in backingDictionary {
-			if !other.backingDictionary.keys.contains(key) {
-				return false
-			}
+            if !other.backingDictionary.keys.contains(key) {
+                return false
+            }
         }
 
         return true
@@ -193,9 +193,9 @@ public struct CountedSet<T: Hashable>: SetAlgebra {
 
     public func isSuperset(of other: CountedSet<Element>) -> Bool {
         for (key, _) in other.backingDictionary {
-			if !backingDictionary.keys.contains(key) {
-				return false
-			}
+            if !backingDictionary.keys.contains(key) {
+                return false
+            }
         }
 
         return true
@@ -222,7 +222,7 @@ extension CountedSet: CustomStringConvertible, CustomDebugStringConvertible {
     public var description: String {
         return backingDictionary.description
     }
-
+    
     public var debugDescription: String {
         return backingDictionary.debugDescription
     }

--- a/Sources/CountedSet.swift
+++ b/Sources/CountedSet.swift
@@ -87,16 +87,21 @@ public struct CountedSet<T: Hashable>: SetAlgebra {
 
     @discardableResult
     public mutating func remove(_ member: CountedSet.Element) -> CountedSet.Element? {
+        return remove(member, count: 1)
+    }
+
+    @discardableResult
+    public mutating func remove(_ member: CountedSet.Element, count: Int = 1) -> CountedSet.Element? {
         guard let value = backingDictionary[member] else {
             return nil
         }
 
-        if value > 1 {
-            backingDictionary[member] = (value - 1)
+        if value > count {
+            backingDictionary[member] = (value - count)
         } else {
             backingDictionary.removeValue(forKey: member)
         }
-
+        
         return member
     }
 

--- a/Sources/CountedSet.swift
+++ b/Sources/CountedSet.swift
@@ -71,11 +71,16 @@ public struct CountedSet<T: Hashable>: SetAlgebra {
 
     @discardableResult
     public mutating func update(with newMember: T) -> T? {
+        return update(with: newMember, count: 1)
+    }
+
+    @discardableResult
+    public mutating func update(with newMember: T, count: Int) -> T? {
         if let existing = backingDictionary[newMember] {
-            backingDictionary[newMember] = (existing + 1)
+            backingDictionary[newMember] = (existing + count)
             return newMember
         } else {
-            backingDictionary[newMember] = 1
+            backingDictionary[newMember] = count
             return nil
         }
     }

--- a/Tests/CountedSetTests/SetsTests.swift
+++ b/Tests/CountedSetTests/SetsTests.swift
@@ -68,6 +68,24 @@ class SetsTests: XCTestCase {
         XCTAssert(countedSet.count == 1)
     }
 
+    func testRemoveWithCount() {
+        var countedSet: CountedSet<Int> = [1,42,42,42,42,42,3,4]
+
+        XCTAssertEqual(countedSet.countForObject(42), 5)
+
+        countedSet.remove(42)
+        XCTAssertEqual(countedSet.countForObject(42), 4)
+
+        countedSet.remove(42, count: 2)
+        XCTAssertEqual(countedSet.countForObject(42), 2)
+
+        countedSet.remove(42, count: 2)
+        XCTAssertFalse(countedSet.contains(42))
+
+        countedSet.remove(1, count: 55)
+        XCTAssertFalse(countedSet.contains(1))
+    }
+
     func testCountForObject() {
         var countedSet = CountedSet<Int>([1, 2, 3, 4, 5])
 

--- a/Tests/CountedSetTests/SetsTests.swift
+++ b/Tests/CountedSetTests/SetsTests.swift
@@ -40,6 +40,18 @@ class SetsTests: XCTestCase {
         XCTAssert(countedSet.count == 16)
     }
 
+    func testUpdate() {
+        var countedSet = CountedSet<Int>([1, 2, 3, 4, 5])
+
+        XCTAssertEqual(countedSet.countForObject(3), 1)
+
+        countedSet.update(with: 3)
+        countedSet.update(with: 3, count: 2)
+        countedSet.update(with: 3, count: 3)
+
+        XCTAssertEqual(countedSet.countForObject(3), 7)
+    }
+    
     func testRemove() {
         var countedSet = CountedSet<Int>()
         countedSet.insert(42)

--- a/Tests/CountedSetTests/SetsTests.swift
+++ b/Tests/CountedSetTests/SetsTests.swift
@@ -15,7 +15,7 @@ class SetsTests: XCTestCase {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
-    
+
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
@@ -29,11 +29,11 @@ class SetsTests: XCTestCase {
         }
 
         for i in 5...15 {
-			let (inserted, element) = countedSet.insert(i)
+            let (inserted, element) = countedSet.insert(i)
 
-			if !inserted {
-				countedSet.update(with: element)
-			}
+            if !inserted {
+                countedSet.update(with: element)
+            }
         }
 
         print(countedSet)
@@ -43,7 +43,7 @@ class SetsTests: XCTestCase {
     func testRemove() {
         var countedSet = CountedSet<Int>()
         countedSet.insert(42)
-		countedSet.update(with: 42)
+        countedSet.update(with: 42)
         countedSet.update(with: 42)
         countedSet.insert(17)
         print(countedSet)
@@ -61,8 +61,8 @@ class SetsTests: XCTestCase {
 
         XCTAssert(countedSet.countForObject(3) == 1)
 
-		countedSet.update(with: 3)
-		countedSet.update(with: 3)
+        countedSet.update(with: 3)
+        countedSet.update(with: 3)
 
         XCTAssert(countedSet.countForObject(3) == 3)
 
@@ -83,7 +83,7 @@ class SetsTests: XCTestCase {
         countedSet2.insert(2)
         countedSet2.insert(3)
         countedSet2.insert(4)
-        
+
         let union = countedSet1.union(countedSet2)
 
         print(union)
@@ -196,14 +196,14 @@ class SetsTests: XCTestCase {
 
         countedSet1.insert(0)
         countedSet1.insert(1)
-		countedSet1.update(with: 1)
-		countedSet1.update(with: 1)
+        countedSet1.update(with: 1)
+        countedSet1.update(with: 1)
 
         XCTAssert(countedSet1.count == 2)
 
         countedSet1.remove(1)
-		countedSet1.remove(1)
-		countedSet1.remove(1)
+        countedSet1.remove(1)
+        countedSet1.remove(1)
         countedSet1.remove(2)
 
         XCTAssert(countedSet1.count == 1)
@@ -242,21 +242,21 @@ class SetsTests: XCTestCase {
         XCTAssert(countedSet1.isDisjoint(with: countedSet2))
         XCTAssert(!countedSet1.isDisjoint(with: countedSet3))
     }
-
+    
     func testIsDisjoint() {
         let a = 4
         let b = 5
         let c = 4
-
+        
         XCTAssert(CountedSet.element(a, isDisjointWith: b))
         XCTAssert(!CountedSet.element(a, isDisjointWith: c))
     }
-
+    
     func testEquality() {
         let countedSet1 = CountedSet([1, 2, 3])
         let countedSet2 = CountedSet([1, 2, 3])
         let countedSet3 = CountedSet([4, 5, 6])
-
+        
         XCTAssert(countedSet1 == countedSet2)
         XCTAssert(countedSet1 != countedSet3)
     }


### PR DESCRIPTION
I would also like to rename `countForObject(_ object: Element)` to `count(of object: Element)` to follow the Swift naming guidelines. You would then call it with `countedSet.count(of: “string”)`. What do you think?